### PR TITLE
Entferne Token nach deaktivieren

### DIFF
--- a/lib/one_time_password_config.php
+++ b/lib/one_time_password_config.php
@@ -75,6 +75,7 @@ final class rex_one_time_password_config
     public function disable()
     {
         $this->enabled = false;
+        $this->provisioningUri = null;
 
         return $this->save();
     }


### PR DESCRIPTION
Der Token sollte nach dem Deaktivieren entfernt werden.

Sonst wird beim wieder aktivieren der gleiche Token verwendet, das problematisch sein kann, wenn der vorherige Token bspw. kompromittiert ist.