### PR TITLE
Period email, E-Mail initial, Methodenupdate

### DIFF
--- a/fragments/2fa.setup-email.php
+++ b/fragments/2fa.setup-email.php
@@ -5,6 +5,7 @@
     <?= $this->message ?>
 <?php endif; ?>
 
+<?php if (!$this->success) : ?>
 <div class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title">2. <?= $this->addon->i18n('2fa_verify_headline') ?></h3>
@@ -31,4 +32,4 @@
         </form>
     </div>
 </div>
-
+<?php endif; ?>

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -27,3 +27,4 @@
 2factor_auth_copy = Kopieren
 
 2factor_auth_login = Authentifizierungs App starten und Code eingeben
+2fa_setup_start_email_send = E-Mail wurde versendet

--- a/lib/method_email.php
+++ b/lib/method_email.php
@@ -50,7 +50,7 @@ final class method_email implements method_interface
     public function getProvisioningUri(rex_user $user)
     {
         // create a uri with a random secret
-        $otp = TOTP::create(null, 60);
+        $otp = TOTP::create(null, 300);
 
         // the label rendered in "Google Authenticator" or similar app
         $label = $user->getLogin() . '@' . rex::getServerName() . ' (' . $_SERVER['HTTP_HOST'] . ')';

--- a/lib/method_totp.php
+++ b/lib/method_totp.php
@@ -36,6 +36,7 @@ final class method_totp implements method_interface
     public function getProvisioningUri(rex_user $user)
     {
         // create a uri with a random secret
+        // default period is 30s and digest is sha1. Google Authenticator is restricted to this settings
         $otp = TOTP::create();
 
         // the label rendered in "Google Authenticator" or similar app

--- a/lib/one_time_password_config.php
+++ b/lib/one_time_password_config.php
@@ -137,6 +137,16 @@ final class one_time_password_config
     /**
      * @return void
      */
+    public function updateMethod(method_interface $method)
+    {
+        $this->method = $method instanceof method_email ? 'email' : 'totp';
+        $this->provisioningUri = $method->getProvisioningUri($this->user);
+        $this->save();
+    }
+
+    /**
+     * @return void
+     */
     private function save()
     {
         $userSql = rex_sql::factory();


### PR DESCRIPTION
kommt etwas zusammen, weil die voneinander abhängig sind.

- Periodtime bei E-Mail OTP ist nun 5 Minuten
- Methoden wurden nicht in der Laufzeit beim User gesetzt, was dazu führte, dass initial keine E-Mail versendet wurde, oder eine E-Mail bei totp fälschlicherweise verschickt wurde